### PR TITLE
Support per request configuration and optional redirects

### DIFF
--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -22,17 +22,17 @@ module TrackyDacks
       plugin_opts = app.opts[:tracky_dacks] = {}
 
       plugin_opts[:runner] = runner
-
-      plugin_opts[:handlers] = handlers.each_with_object({}) { |(key, handler_class), result|
-        result[key] = handler_class.new(handler_options)
-      }
+      plugin_opts[:handlers] = handlers
+      plugin_opts[:handler_options] = handler_options
     end
 
     module RequestMethods
-      def tracky_dacks_routes
+      def tracky_dacks_routes(**handler_options)
         get do
-          roda_class.opts[:tracky_dacks][:handlers].each_pair do |key, handler|
+          roda_class.opts[:tracky_dacks][:handlers].each_pair do |key, handler_class|
             on /#{key}\.?(\w+)?/ do |format|
+              handler = handler_class.new(roda_class.opts[:tracky_dacks][:handler_options].merge(handler_options))
+
               roda_class.opts[:tracky_dacks][:runner].(
                 handler,
                 params.merge("referrer": referrer)

--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -35,7 +35,7 @@ module TrackyDacks
 
               roda_class.opts[:tracky_dacks][:runner].(
                 handler,
-                params.merge("referrer": referrer)
+                params.merge("referrer" => referrer)
               )
 
               if format == "png"

--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -40,9 +40,14 @@ module TrackyDacks
 
               if format == "png"
                 send_file IMAGE_PATH, disposition: "inline"
-              else
+              elsif params["target"]
                 status_code = Integer(params.fetch("redirect", 302))
                 redirect params["target"], status_code
+              else
+                halt [200, {
+                  "Content-Type" => "text/html",
+                  "Access-Control-Allow-Origin" => "*"
+                  }, []]
               end
             end
           end


### PR DESCRIPTION
Hi 👋 

This PR adds two features that we need for a new analytics tracking app. Firstly, we need the ability to support creating handlers as part of the request, so that we can use tracky_dacks to track analytics for subroutes. The end goal of this is that:
`/route1/event.json?...` and
`/route2/event.json?...` track against different UIDs, which we pass in as part of the `handler_options` at request time.

Secondly, we need to make redirects on the requests optional. We now only redirect if a `target` parameter is present, and otherwise we return a 200 response. Potentially there is a better way to achieve this, if you'd like me to try a different approach please let me know! eg: I could redirect to the referrer?
