### PR TITLE
[WIP] Add support for tracking dimesions/metrics

### DIFF
--- a/lib/tracky_dacks/handlers/event.rb
+++ b/lib/tracky_dacks/handlers/event.rb
@@ -4,7 +4,7 @@ module TrackyDacks
   module Handlers
     class Event < GA
       def call(params = {})
-        tracker.event(
+        hit = tracker.build_event(
           document_location: params["location"],
           document_title: params["title"],
           document_path: params["path"],
@@ -13,6 +13,9 @@ module TrackyDacks
           action: params["action"],
           label: params["label"],
         )
+        add_custom_dimensions(hit, params)
+        add_custom_metrics(hit, params)
+        hit.track!
       end
     end
   end

--- a/lib/tracky_dacks/handlers/ga.rb
+++ b/lib/tracky_dacks/handlers/ga.rb
@@ -23,6 +23,30 @@ module TrackyDacks
 
         Staccato.tracker(tracking_id, client_id, options)
       end
+
+      def add_custom_dimensions(hit, params)
+        params.select {|param|
+          param.start_with? "cd"
+        }.each do |param, value|
+          dimension_index = param.gsub(/\Acd/, "")
+          hit.add_custom_dimension(
+            dimension_index,
+            value
+          )
+        end
+      end
+
+      def add_custom_metrics(hit, params)
+        params.select {|param|
+          param.start_with? "cm"
+        }.each do |param, value|
+          metric_index = param.gsub(/\Acm/, "")
+          hit.add_custom_metric(
+            metric_index,
+            value
+          )
+        end
+      end
     end
   end
 end

--- a/lib/tracky_dacks/handlers/pageview.rb
+++ b/lib/tracky_dacks/handlers/pageview.rb
@@ -4,7 +4,7 @@ module TrackyDacks
   module Handlers
     class Pageview < GA
       def call(params = {})
-        tracker.pageview(
+        hit = tracker.build_pageview(
           document_location: params["location"],
           document_title: params["title"],
           document_path: params["path"],
@@ -16,6 +16,9 @@ module TrackyDacks
           campaign_content: params["campaign_content"],
           campaign_id: params["campaign_id"]
         )
+        add_custom_dimensions(hit, params)
+        add_custom_metrics(hit, params)
+        hit.track!
       end
     end
   end

--- a/lib/tracky_dacks/handlers/social.rb
+++ b/lib/tracky_dacks/handlers/social.rb
@@ -4,7 +4,7 @@ module TrackyDacks
   module Handlers
     class Social < GA
       def call(params = {})
-        tracker.social(
+        hit = tracker.build_social(
           document_location: params["location"],
           document_title: params["title"],
           document_path: params["path"],
@@ -13,6 +13,9 @@ module TrackyDacks
           network: params["network"],
           target: params["target"],
         )
+        add_custom_dimensions(hit, params)
+        add_custom_metrics(hit, params)
+        hit.track!
       end
     end
   end


### PR DESCRIPTION
Params are line with [the way GA handles these](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cd_):

* `cd<Index>=value` for dimensions
* `cm<Index>=value` for metrics

Because we need access to the `hit` we have to call `build_<type>`