### PR TITLE
Add support for truncated endpoints, params and param inference.

### DIFF
--- a/lib/tracky_dacks/params_builder.rb
+++ b/lib/tracky_dacks/params_builder.rb
@@ -2,6 +2,16 @@ require "uri"
 
 module TrackyDacks
   class ParamsBuilder
+    def self.build(params, options = {})
+      request_params = options[:enable_truncation] ? params.merge(expand_truncated(params)) : params
+
+      if Array(options[:infer]).any?
+        request_params = request_params.merge(infer_params(Array(options[:infer]), request_params))
+      end
+
+      request_params
+    end
+
     def self.expand_truncated(params)
       {
         "action"           => params["a"],

--- a/lib/tracky_dacks/params_builder.rb
+++ b/lib/tracky_dacks/params_builder.rb
@@ -1,0 +1,61 @@
+require "uri"
+
+module TrackyDacks
+  class ParamsBuilder
+    attr_reader :params
+
+    def initialize(params = {})
+      @params = params
+    end
+
+    def build
+      request_params = params.merge(expanded_params)
+
+      infered_params = infer_params(request_params)
+
+      request_params.merge(infered_params)
+    end
+
+    private
+
+    def expanded_params
+      {
+        "action"           => params["a"],
+        "campaign_content" => params["cc"],
+        "campaign_id"      => params["ci"],
+        "campaign_keyword" => params["ck"],
+        "campaign_medium"  => params["cm"],
+        "campaign_name"    => params["cn"],
+        "campaign_source"  => params["cs"],
+        "category"         => params["c"],
+        "label"            => params["la"],
+        "location"         => params["l"],
+        "network"          => params["n"],
+        "path"             => params["p"],
+        "redirect"         => params["r"],
+        "target"           => params["t"],
+        "title"            => params["ti"],
+      }.compact
+    end
+
+    def infer_params(request_params)
+      result = {}
+
+      # Use target for the location param if no location is specified.
+      unless request_params["location"]
+        result["location"] = request_params["target"]
+      end
+
+      # Infer path from target unless path is specified.
+      unless request_params["path"]
+        begin
+          result["path"] = URI.parse(request_params["target"]).path
+        rescue StandardError => e
+          nil
+        end
+      end
+
+      result
+    end
+  end
+end

--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -46,20 +46,7 @@ module TrackyDacks
                   false
                 end
 
-              params_options = roda_class.opts[:tracky_dacks][:params_options]
-
-              request_params =
-                if params_options[:enable_truncation]
-                  params.merge(ParamsBuilder.expand_truncated(params))
-                else
-                  params
-                end
-
-              inferred_params_list = Array(params_options[:infer])
-
-              if inferred_params_list.any?
-                request_params = request_params.merge(ParamsBuilder.infer_params(inferred_params_list, request_params))
-              end
+              request_params = ParamsBuilder.build(params, roda_class.opts[:tracky_dacks][:params_options])
 
               additional_params = {"referrer" => referrer, "user_agent" => user_agent}.compact
 

--- a/lib/tracky_dacks/plugin.rb
+++ b/lib/tracky_dacks/plugin.rb
@@ -48,7 +48,7 @@ module TrackyDacks
 
               request_params = ParamsBuilder.build(params, roda_class.opts[:tracky_dacks][:params_options])
 
-              additional_params = {"referrer" => referrer, "user_agent" => user_agent}.compact
+              additional_params = {"referrer" => referrer, "user_agent" => user_agent}
 
               roda_class.opts[:tracky_dacks][:runner].(
                 handler,

--- a/spec/tracky_dacks_spec.rb
+++ b/spec/tracky_dacks_spec.rb
@@ -22,12 +22,46 @@ RSpec.describe "TrackyDacks" do
   end
 
   it "tracks requests passed to a Roda app" do
-    env = {"REQUEST_METHOD" => "GET", "PATH_INFO" => "/social", "QUERY_STRING" => "target=/test", "SCRIPT_NAME" => "", "rack.input" => StringIO.new}
+    env = {"REQUEST_METHOD" => "GET", "PATH_INFO" => "/event", "QUERY_STRING" => "target=/test", "SCRIPT_NAME" => "", "rack.input" => StringIO.new}
     response = rack_app.(env)
 
     expect(response[0]).to eq 302
     expect(response[1]).to eq({"Location"=>"/test", "Content-Type"=>"text/html", "Content-Length"=>"0"})
     expect(runner).to have_received(:call)
+  end
+
+  context "with a truncated path and truncated params" do
+    it "tracks requests passed to a Roda app by expanding truncated path and params" do
+      env = {"REQUEST_METHOD" => "GET", "PATH_INFO" => "/e", "QUERY_STRING" => "t=https%3A%2F%2Fwww.example.com%2Ftest&a=read&ti=Foobar&c=Podcasts", "SCRIPT_NAME" => "", "rack.input" => StringIO.new}
+      response = rack_app.(env)
+
+      expect(response[0]).to eq 302
+      expect(response[1]).to eq({"Location"=>"https://www.example.com/test", "Content-Type"=>"text/html", "Content-Length"=>"0"})
+      expect(runner).to have_received(:call).with(
+        instance_of(TrackyDacks::Handlers::Event),
+        hash_including(
+          "action" => "read",
+          "category" => "Podcasts",
+          "target" => "https://www.example.com/test",
+          "title" => "Foobar",
+        )
+      )
+    end
+
+    it "infers location and path from the target param if needed" do
+      env = {"REQUEST_METHOD" => "GET", "PATH_INFO" => "/s", "QUERY_STRING" => "t=https%3A%2F%2Fwww.example.com%2Ftest", "SCRIPT_NAME" => "", "rack.input" => StringIO.new}
+      response = rack_app.(env)
+
+      expect(response[0]).to eq 302
+      expect(response[1]).to eq({"Location"=>"https://www.example.com/test", "Content-Type"=>"text/html", "Content-Length"=>"0"})
+      expect(runner).to have_received(:call).with(
+        instance_of(TrackyDacks::Handlers::Social),
+        hash_including(
+          "location" => "https://www.example.com/test",
+          "path" => "/test"
+        )
+      )
+    end
   end
 
   describe "skip_tracking_if option" do


### PR DESCRIPTION
This adds support for:

- truncated endpoints. e.g. `/e` as well as `/event`
- truncated params. e.g. `ti=foo` as well as `title=foo`
- inferring path and location from the target param if needed